### PR TITLE
Fixed cap sensitive bug

### DIFF
--- a/polyglot.js
+++ b/polyglot.js
@@ -73,7 +73,7 @@ class PolyGlot {
 			try {
 				// Don't duplicate the value in case it's a not an array
 				for (let lang of actor.data.data.traits.languages.value)
-				    this.known_languages.add(lang)
+				    this.known_languages.add(lang.toLowerCase())
 			} catch (err) { 
 				// Maybe not dnd5e, pf1 or pf2e or corrupted actor data?
 			}


### PR DESCRIPTION
Fixed cap sensitive bug where langs were not translated because they are stored with the first letter as capital. (pathfinder 2e)