### PR TITLE
chatBubble's window size + custom languages on actorsheets

### DIFF
--- a/polyglot.js
+++ b/polyglot.js
@@ -455,7 +455,7 @@ class PolyGlot {
     }
     chatBubble (token, html, message, {emote}) {
         message = game.messages.get(game.messages._source[game.messages._source.length-1]._id);
-        if (message.type == CONST.CHAT_MESSAGE_TYPES.IC) {
+        if (message.data.type == CONST.CHAT_MESSAGE_TYPES.IC) {
             let lang = message.getFlag("polyglot", "language") || ""
             if (lang != "") {
                 const unknown = !this.known_languages.has(lang);
@@ -464,7 +464,7 @@ class PolyGlot {
                     message.polyglot_unknown = false;
                 if (!message.polyglot_force && message.polyglot_unknown) {
                     const content = html.find(".bubble-content")
-                    const new_content = this.scrambleString(message.content, game.settings.get('polyglot','useUniqueSalt') ? message._id : lang)
+                    const new_content = this.scrambleString(message.data.content, game.settings.get('polyglot','useUniqueSalt') ? message._id : lang)
                     content.text(new_content)
                     content[0].style.font = this._getFontStyle(lang)
                     message.polyglot_unknown = true;

--- a/polyglot.js
+++ b/polyglot.js
@@ -453,8 +453,8 @@ class PolyGlot {
             }
         }
     }
-    chatBubble (token, html, message, {emote}) {
-        message = game.messages.get(game.messages._source[game.messages._source.length-1]._id);
+    chatBubble (token, html, messageContent, {emote}) {
+        const message = game.messages.entities.slice(-10).reverse().find(m => m.data.content === messageContent);
         if (message.data.type == CONST.CHAT_MESSAGE_TYPES.IC) {
             let lang = message.getFlag("polyglot", "language") || ""
             if (lang != "") {

--- a/polyglot.js
+++ b/polyglot.js
@@ -311,6 +311,19 @@ class PolyGlot {
             default: false,
             type: Boolean
         });
+        // Adjust the bubble dimensions so the message is displayed correctly
+        ChatBubbles.prototype._getMessageDimensions = (message) => {
+            let div = $(`<div class="chat-bubble" style="visibility:hidden;font:${this._bubble.font}">${this._bubble.message || message}</div>`);
+            $('body').append(div);
+            let dims = {
+                width: div[0].clientWidth + 8,
+                height: div[0].clientHeight
+            };
+            div.css({maxHeight: "none"});
+            dims.unconstrained = div[0].clientHeight;
+            div.remove();
+            return dims;
+        }
     }
 
     ready() {
@@ -460,6 +473,7 @@ class PolyGlot {
     }
     chatBubble (token, html, messageContent, {emote}) {
         const message = game.messages.entities.slice(-10).reverse().find(m => m.data.content === messageContent);
+        this._bubble = { font: '', message: '' };
         if (message.data.type == CONST.CHAT_MESSAGE_TYPES.IC) {
             let lang = message.getFlag("polyglot", "language") || ""
             if (lang != "") {
@@ -471,7 +485,9 @@ class PolyGlot {
                     const content = html.find(".bubble-content")
                     const new_content = this.scrambleString(message.data.content, game.settings.get('polyglot','useUniqueSalt') ? message._id : lang)
                     content.text(new_content)
-                    content[0].style.font = this._getFontStyle(lang)
+                    this._bubble.font = this._getFontStyle(lang)
+                    this._bubble.message = new_content
+                    content[0].style.font = this._bubble.font
                     message.polyglot_unknown = true;
                 }
             }

--- a/polyglot.js
+++ b/polyglot.js
@@ -311,6 +311,19 @@ class PolyGlot {
             default: false,
             type: Boolean
         });
+        // Adjust the bubble dimensions so the message is displayed correctly
+        ChatBubbles.prototype._getMessageDimensions = (message) => {
+            let div = $(`<div class="chat-bubble" style="visibility:hidden;font:${this.bubbleFont}">${message}</div>`);
+            $('body').append(div);
+            let dims = {
+                width: div[0].clientWidth + 8,
+                height: div[0].clientHeight
+            };
+            div.css({maxHeight: "none"});
+            dims.unconstrained = div[0].clientHeight;
+            div.remove();
+            return dims;
+        }
     }
 
     ready() {
@@ -471,7 +484,8 @@ class PolyGlot {
                     const content = html.find(".bubble-content")
                     const new_content = this.scrambleString(message.data.content, game.settings.get('polyglot','useUniqueSalt') ? message._id : lang)
                     content.text(new_content)
-                    content[0].style.font = this._getFontStyle(lang)
+                    this.bubbleFont = this._getFontStyle(lang)
+                    content[0].style.font = this.bubbleFont
                     message.polyglot_unknown = true;
                 }
             }

--- a/polyglot.js
+++ b/polyglot.js
@@ -137,6 +137,11 @@ class PolyGlot {
                         // Don't duplicate the value in case it's a not an array
                         for (let lang of actor.data.data.traits.languages.value)
                             this.known_languages.add(lang)
+                        // This condition is needed so an empty language is not loaded
+                        if (actor.data.data.traits.languages.custom != "") {
+                            for (let lang of actor.data.data.traits.languages.custom.split(/[,;]/))
+                                this.known_languages.add(lang)
+                        }
                         break;
                 }
             } catch (err) {

--- a/polyglot.js
+++ b/polyglot.js
@@ -311,19 +311,6 @@ class PolyGlot {
             default: false,
             type: Boolean
         });
-        // Adjust the bubble dimensions so the message is displayed correctly
-        ChatBubbles.prototype._getMessageDimensions = (message) => {
-            let div = $(`<div class="chat-bubble" style="visibility:hidden;font:${this.bubbleFont}">${message}</div>`);
-            $('body').append(div);
-            let dims = {
-                width: div[0].clientWidth + 8,
-                height: div[0].clientHeight
-            };
-            div.css({maxHeight: "none"});
-            dims.unconstrained = div[0].clientHeight;
-            div.remove();
-            return dims;
-        }
     }
 
     ready() {
@@ -484,8 +471,7 @@ class PolyGlot {
                     const content = html.find(".bubble-content")
                     const new_content = this.scrambleString(message.data.content, game.settings.get('polyglot','useUniqueSalt') ? message._id : lang)
                     content.text(new_content)
-                    this.bubbleFont = this._getFontStyle(lang)
-                    content[0].style.font = this.bubbleFont
+                    content[0].style.font = this._getFontStyle(lang)
                     message.polyglot_unknown = true;
                 }
             }


### PR DESCRIPTION
- Fixed the chatBubble's window size not being displayed correctly (this was a known issue);
- The module now also reads custom languages directly in actorsheets in 5e and pf1 and pf2e, no need to add a language for the world because of one NPC, lots of NPCs (and compendiums) now work correctly language-wise -> less work for the DM.