### PR TITLE
Use already defined TinyMCE style_formats

### DIFF
--- a/module.json
+++ b/module.json
@@ -11,6 +11,6 @@
     "url": "https://github.com/kakaroto/fvtt-module-polyglot",
     "manifest": "https://raw.githubusercontent.com/kakaroto/fvtt-module-polyglot/master/module.json",
     "download": "https://github.com/kakaroto/fvtt-module-polyglot/archive/v1.4.0.zip",
-    "minimumCoreVersion": "0.6.0",
+    "minimumCoreVersion": "0.7.6",
     "compatibleCoreVersion": "0.8.0"
 }

--- a/polyglot.js
+++ b/polyglot.js
@@ -394,17 +394,7 @@ class PolyGlot {
         });
         sheet[methodName] = function(target, editorOptions, initialContent) {
             editorOptions.style_formats = [
-              {
-                title: "Custom",
-                items: [
-                  {
-                    title: "Secret",
-                    block: 'section',
-                    classes: 'secret',
-                    wrapper: true
-                  }
-                ]
-              },
+              ...CONFIG.TinyMCE.style_formats,
               {
                 title: "Polyglot",
                 items: languages


### PR DESCRIPTION
If another module defines their own style formats in the default TinyMCE config (added in 0.7.6, see https://gitlab.com/foundrynet/foundryvtt/-/issues/3808), the previous code would overwrite them. This change will make use of the pre-defined custom style formats rather than overwriting them.